### PR TITLE
fixed a search bug of regex

### DIFF
--- a/source/js/search.js
+++ b/source/js/search.js
@@ -81,6 +81,8 @@
     }
 
     function matcher(post, regExp) {
+        
+        regExp.lastIndex = 0;
 
         return regExp.test(post.title) || post.tags.some(function(tag) {
             return regExp.test(tag.name);

--- a/source/js/search.js
+++ b/source/js/search.js
@@ -79,14 +79,14 @@
 
         searchResult.innerHTML = html;
     }
-
-    function matcher(post, regExp) {
-        
+    function regtest(raw, regExp) {
         regExp.lastIndex = 0;
-
-        return regExp.test(post.title) || post.tags.some(function(tag) {
-            return regExp.test(tag.name);
-        }) || regExp.test(post.text);
+        return regExp.test(raw);
+    }
+    function matcher(post, regExp) {
+        return regtest(post.title, regExp) || post.tags.some(function(tag) {
+            return regtest(tag.name, regExp);
+        }) || regtest(post.text, regExp);
     }
 
     function search(e) {


### PR DESCRIPTION
js的regexp每次测试之后都会将lastIndex设为上次获得匹配的结束位置+1，导致出现以下一类情况时无法获得预期的结果

有两篇文章
在content.json中出现的较前的一篇的title为"BZOJ1500维修数列"，较后的一篇title为"BZOJ1014火星人prefix"
在搜索框中输入"bz"时，结果中只会出现第一篇
test完第一篇之后，lastIndex移到2，实际上只能够test到第二篇文章"OJ1014火星人prefix"的这一部分

解决方案：matcher中添加`regExp.lastIndex = 0;`

参考：<http://ilanever.com/article/detail.do;jsessionid=CA936328F0522E9E38589B817D8EDC6B?id=253>