### PR TITLE
Correct the Disqus config

### DIFF
--- a/layout/_partial/post/comment.ejs
+++ b/layout/_partial/post/comment.ejs
@@ -6,7 +6,7 @@
   }) %>
 <% } %>
 
-<% if (post.comments && config.disqus_shortname){ %>
+<% if (post.comments && theme.disqus_shortname){ %>
 <section id="comments">
   <div id="disqus_thread"></div>
     <script type="text/javascript">


### PR DESCRIPTION
I cannot use Disqus in my GitHub Page when using this theme.So, I change only a wrong word to support Disqus correctly. Anyway,thanks a lot for your Indigo Theme.