### PR TITLE
mathjax cdn地址修改为https，增加mathjax官网建议的async关键词

### DIFF
--- a/layout/_partial/mathjax.ejs
+++ b/layout/_partial/mathjax.ejs
@@ -17,4 +17,4 @@ MathJax.Hub.Queue(function() {
 });
 </script>
 
-<script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+<script type="text/javascript" async src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>

--- a/layout/_partial/mathjax.ejs
+++ b/layout/_partial/mathjax.ejs
@@ -17,4 +17,4 @@ MathJax.Hub.Queue(function() {
 });
 </script>
 
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>


### PR DESCRIPTION
从http修改到https可以避免在gihhub pages https化之后部署的博客，因为加载http的mathjax脚本导致chrome弹出的load unsafe script提示，在地址栏显示小红锁