### PR TITLE
fix "index.html" in BLOG_SHARE's url

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -6,7 +6,7 @@ var BLOG_SHARE = {
     title: "<%-(page.title || config.title) %>",
     pic: "<%=theme.avatar %>",
     summary: document.getElementsByName('summary')[0].content,
-    url: "<%=url %>"
+    url: "<%=page.permalink %>"
 };
 </script>
 <%- partial('post/share', {className: 'global-share'}) %>


### PR DESCRIPTION
将分享按钮的 url 改为page.permalink，达到去除"index.html"的效果。