### PR TITLE
add custom head

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -50,4 +50,12 @@
     <%- favicon_tag(theme.favicon) %>
     <link rel="stylesheet" href="<%- url_for(theme_css('/css/style', cache)) %>">
     <script>window.lazyScripts=[]</script>
+
+    <!-- custom head -->
+    <% if (site.data.head) { %>
+        <% for (var i in site.data.head) { %>
+            <%- site.data.head[i] %>
+        <% } %>
+    <% } %>
+
 </head>


### PR DESCRIPTION
用户可以在 `Blog/sources/_date/head.yml` 中直接添加head的内容  
如：
```
css: "<link href='/css/My.css' rel='stylesheet' type='text/css' />"
js: "<script type='text/javascript' src='/js/My.js'></script>"
```
这样就可以直接添加自己需要的信息到头部了


代码来自于 [Material Theme](https://github.com/viosey/hexo-theme-material/blob/master/layout/_partial/head.ejs#L178)
[说明文档](https://material.viosey.com/expert/#添加自定义代码)
如果想要在站点添加自定义 `font-face` 或者统计代码（例如 Google Analytics）。
需要在 `hexo` 目录下的 `source` 文件夹内创建一个名为 `_data`（禁止改名）的文件夹，并在文件内创建一个名为 `head.yml` 的文件。
单个代码格式为：
```
Name: "put your code here"
````
代码将显示在 `</head>` 之前，
`Name `将作为注释显示在代码上方。





