### PR TITLE
文章页留言postMessage可关闭

### DIFF
--- a/layout/_partial/post/copyright.ejs
+++ b/layout/_partial/post/copyright.ejs
@@ -1,10 +1,10 @@
 <blockquote class="post-copyright">
-    <div class="content">
-        <%- partial('updated') %>
+    <%- partial('updated') %>
         <% if(theme.postMessage) {%>
-        <%- _.template(theme.postMessage)(locals) %>
-        <% } %>
-    </div>
+        <div class="content">
+            <%- _.template(theme.postMessage)(locals) %>
+        </div>
+    <% } %>
     <footer>
         <a href="<%- config.url %>">
             <img src="<%- url_for(theme.avatar) %>" alt="<%- config.author %>">


### PR DESCRIPTION
`postMessage: null | false` 或者注释掉可关闭文章留言模块

原代码设置postMessage为空时会保留带有样式的空div.content，修改后将div.content包含在条件语句中