### PR TITLE
解决加密文章寻找不到Toc列表错误

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -110,7 +110,10 @@
                 headerH = header.clientHeight,
                 titles = $('#post-content').querySelectorAll('h1, h2, h3, h4, h5, h6');
 
-            toc.querySelector('a[href="#' + titles[0].id + '"]').parentNode.classList.add('active');
+            var firstLink = titles.length > 0 ? toc.querySelector('a[href="#' + titles[0].id + '"]') : toc.querySelectorAll('a')[0];
+
+            if (firstLink)
+                firstLink.parentNode.classList.add('active');
 
             // Make every child shrink initially
             var tocChilds = toc.querySelectorAll('.post-toc-child');
@@ -118,8 +121,7 @@
                 tocChilds[i].classList.add('post-toc-shrink');
             }
             var firstChild =
-                toc.querySelector('a[href="#' + titles[0].id + '"]')
-                    .nextElementSibling;
+                firstLink.nextElementSibling;
             if (firstChild) {
                 firstChild.classList.add('post-toc-expand');
                 firstChild.classList.remove('post-toc-shrink');
@@ -152,6 +154,11 @@
                     top >= bannerH - headerH ? toc.classList.add('fixed') : toc.classList.remove('fixed');
                 },
                 actived: function (top) {
+
+                    if (titles.length == 0) {
+                        titles = $('#post-content').querySelectorAll('h1, h2, h3, h4, h5, h6');
+                    }
+
                     for (i = 0, len = titles.length; i < len; i++) {
                         if (top > offset(titles[i]).y - headerH - 5) {
                             var prevListEle = toc.querySelector('li.active');
@@ -161,7 +168,7 @@
                         }
                     }
 
-                    if (top < offset(titles[0]).y) {
+                    if (titles.length > 0 && top < offset(titles[0]).y) {
                         handleTocActive(
                             toc.querySelector('li.active'),
                             toc.querySelector('a[href="#' + titles[0].id + '"]').parentNode


### PR DESCRIPTION
在使用[hexo-blog-encrypt](https://github.com/MikeCoder/hexo-blog-encrypt)等加密插件的时候，
根据配置要求将 layout/_partial/post/toc.ejs改为
```
<% if(theme.toc){  %>
    <aside id="toc-div" class="post-widget" <% if (post.encrypt == true) { %>style="display:none" <% } %>>
        <nav class="post-toc-wrap" post-toc-shrink id="post-toc">
            <h4>TOC</h4>
                <% if (post.encrypt == true) {%>
                    <%- toc(post.origin, {
                            class: 'post-toc',
                            list_number: theme.toc.list_number
                        }) %>
                <% } else { %>
                    <%- toc(post.content, {
                            class: 'post-toc',
                            list_number: theme.toc.list_number
                        }) %>
                <% } %>
        </nav>
    </aside>
    <%
} %>
```
由于文章内容被加密，main.js中titles[0].id会出现 Uncaught TypeError: Cannot read property 'id' of undefined。此处等地适当加了一些判断修改。