### PR TITLE
修复busaunzi统计失效问题，替换busuanzi的cdn

### DIFF
--- a/layout/_partial/script.ejs
+++ b/layout/_partial/script.ejs
@@ -16,7 +16,7 @@ lazyScripts.push('//s95.cnzz.com/z_stat.php?id=<%-theme.cnzz %>&web_id=<%-theme.
 <%- partial('plugins/mathjax') %>
 
 <% if (theme.visit_counter) { %>
-<script async src="//dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js"></script>
+<script async src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
 <% } %>
 
 <%- partial('plugins/dynamic-title') %>


### PR DESCRIPTION
#430 #434 
[cdn更换域名](http://ibruce.info/2015/04/04/busuanzi/)