### PR TITLE
feat: deprecation on  Gitalk: use  Basic Authentication instead of OAuth

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -118,10 +118,9 @@ gitment: false
 
 # use gitalk://github.com/gitalk/gitalk
 gitalk: false
-#  owner: 
-#  repo: 
-#  client_id: 
-#  client_secret: 
+#  owner:
+#  repo:
+#  access_token:
 
 # Valine Comment system. https://valine.js.org
 valine:

--- a/layout/_partial/plugins/gitalk.ejs
+++ b/layout/_partial/plugins/gitalk.ejs
@@ -9,8 +9,7 @@
           id = location.pathname.replace(/\/\d+\/\d+\/\d+\//, '').replace('/', '').substring(0, 50)
         }
         const gitalk = new Gitalk({
-          clientID: '<%- theme.gitalk.client_id %>',
-          clientSecret: '<%- theme.gitalk.client_secret %>',
+          accessToken: '<%- theme.gitalk.access_token %>',
           repo: '<%- theme.gitalk.repo %>',
           owner: '<%- theme.gitalk.owner %>',
           admin: ['<%- theme.gitalk.owner %>'],


### PR DESCRIPTION
根据 github-api 的(最新文档 )[https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param]，gitalk 目前需要替换为 Basic Auth。目前用 OAuth 配置的 gitalk 已经陆陆续续收到了邮件

```
Hi @razertory,

On February 22nd, 2020 at 10:32 (UTC) your application (razertory's blog) used its `client_id` and `client_secret` (with the User-Agent Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/79.0.3945.120 Safari/537.36) as part of a set of query parameters to access an endpoint through the GitHub API:

https://api.github.com/repositories/189442197/issues

Please use Basic Authentication instead as using OAuth credentials in query parameters has been deprecated.

Depending on your API usage, we'll be sending you this email reminder on a monthly basis.

Visit https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param for more information about suggested workarounds and removal dates.

Thanks,
The GitHub Team
```
目前已亲测用如下的改动可以修复这个问题。