### PR TITLE
限制放缩前图片的高度为 500px

### DIFF
--- a/source/css/_partial/lightbox.less
+++ b/source/css/_partial/lightbox.less
@@ -5,6 +5,8 @@
         top: 0;
         left: 0;
         img {
+            max-height:none; //放缩后不限制高度
+            max-width:auto;
             position: absolute;
             z-index: 890;
             &.zoom-in {
@@ -23,7 +25,6 @@
             will-change: opacity;
             .transition(.3s);
         }
-
         .overlay-title {
             position: fixed;
             left: 0;
@@ -38,7 +39,6 @@
             .transition(.3s);
         }
     }
-
     &.active {
         img {
             cursor: -webkit-zoom-out;
@@ -52,10 +52,11 @@
             .transform(translate3d(0, 0, 0));
         }
     }
-
     img {
         display: inline;
         margin: 0;
+        max-height:500px; //放缩前限制高度
+        max-width:auto;
         cursor: -webkit-zoom-in;
         cursor: zoom-in;
 


### PR DESCRIPTION
原版代码没有限制图片的高度，导致对于高度远大于宽度的图，图片会显得很大。如下：

![原版](https://user-images.githubusercontent.com/15522311/88374027-8c0def00-cdcb-11ea-869c-473c30414f53.png)

修改后，限制了放缩之前图片的高度，同时也没有限制放缩（单击图片放缩）后的图片，如下：

![image](https://user-images.githubusercontent.com/15522311/88374209-ec9d2c00-cdcb-11ea-8e0c-ea264f4a6e9f.png)
![image](https://user-images.githubusercontent.com/15522311/88374219-f1fa7680-cdcb-11ea-85ce-99a23e86915d.png)
